### PR TITLE
Refactor/#84-템플릿-삭제-API

### DIFF
--- a/src/controllers/template.controller.js
+++ b/src/controllers/template.controller.js
@@ -1,6 +1,6 @@
 import { StatusCodes } from "http-status-codes";
 import { fullTemplateLoad, templateDeletion , singleTemplateView , getPopularTemplates} from "../services/template.service.js";
-
+import { templateToDetailInfo } from "../dtos/template.dto.js";
 
 // 템플릿 전체 불러오기 요청
 export const handleFullTemplateLoad = async (req, res, next) => {
@@ -198,7 +198,7 @@ export const handleTemplateDelete = async (req, res, next) => {
         console.log("\n템플릿 전체 불러오기를 요청했습니다!");
         console.log(`요청된 템플릿 아이디입니다: ${req.params.templateId}`);
 
-        const deletedTemplate = await templateDeletion(req.params.templateId);
+        const deletedTemplate = await templateDeletion(templateToDetailInfo(req.params));
         res.status(StatusCodes.OK).success(deletedTemplate);
     } catch (error) {
         next(error);

--- a/src/controllers/template.controller.js
+++ b/src/controllers/template.controller.js
@@ -1,6 +1,6 @@
 import { StatusCodes } from "http-status-codes";
 import { fullTemplateLoad, templateDeletion , singleTemplateView , getPopularTemplates} from "../services/template.service.js";
-import { templateToDetailInfo } from "../dtos/template.dto.js";
+import { templateToDelete } from "../dtos/template.dto.js";
 
 // 템플릿 전체 불러오기 요청
 export const handleFullTemplateLoad = async (req, res, next) => {
@@ -198,7 +198,7 @@ export const handleTemplateDelete = async (req, res, next) => {
         console.log("\n템플릿 전체 불러오기를 요청했습니다!");
         console.log(`요청된 템플릿 아이디입니다: ${req.params.templateId}`);
 
-        const deletedTemplate = await templateDeletion(templateToDetailInfo(req.params));
+        const deletedTemplate = await templateDeletion(templateToDelete(req.params));
         res.status(StatusCodes.OK).success(deletedTemplate);
     } catch (error) {
         next(error);

--- a/src/dtos/template.dto.js
+++ b/src/dtos/template.dto.js
@@ -1,3 +1,10 @@
+// 템플릿 상세 정보 조회 DTO (controller->service)
+export const templateToDetailInfo = (template)=>{
+    return{
+      templateId: parseInt(template.templateId),
+    }
+  }
+
 // 템플릿 전체 불러오기 DTO (service->controller)
 export const responseFromTemplate = (templateInfo) => {
     const createdAt = new Date(templateInfo.created_at);

--- a/src/dtos/template.dto.js
+++ b/src/dtos/template.dto.js
@@ -1,10 +1,3 @@
-// 템플릿 상세 정보 조회 DTO (controller->service)
-export const templateToDetailInfo = (template)=>{
-    return{
-      templateId: parseInt(template.templateId),
-    }
-  }
-
 // 템플릿 전체 불러오기 DTO (service->controller)
 export const responseFromTemplate = (templateInfo) => {
     const createdAt = new Date(templateInfo.created_at);
@@ -29,6 +22,13 @@ export const responseFromTemplateAndLike = (templateViewInfo) => {
         filePDF: templateViewInfo.file_pdf,
         fileShareState: templateViewInfo.file_share_state || "",
         fileLikeStatus: templateViewInfo.like_status,
+    };
+};
+
+// 템플릿 삭제 전 DTO (controller->service)
+export const templateToDelete = (template) => {
+    return {
+        templateId: parseInt(template.templateId),
     };
 };
 

--- a/src/services/template.service.js
+++ b/src/services/template.service.js
@@ -44,22 +44,20 @@ export const singleTemplateView = async (userId, templateId) => {
 }
 
   // 템플릿 삭제하기 
-export const templateDeletion = async (templateId) => {
-    const numericTemplateId = parseInt(templateId);
-
-    if (isNaN(numericTemplateId) || numericTemplateId <= 0) {
-        throw new InvalidTemplateIdError("유효하지 않은 templateId 입니다.", { requestedTemplateId : numericTemplateId });
+export const templateDeletion = async (data) => {
+    if (isNaN(data.templateId) || data.templateId <= 0) {
+        throw new InvalidTemplateIdError("유효하지 않은 templateId 입니다.", { requestedTemplateId : data.templateId });
     }
-    const templateExistence = await checkTemplateExists(numericTemplateId);
+    const templateExistence = await checkTemplateExists(data.templateId);
     if (!templateExistence) { // templateInfo가 null일 때 (=없을 때)
-        throw new NonexistentTemplateError("존재하지 않는 template 입니다.",  { requestedTemplateId : numericTemplateId }); 
+        throw new NonexistentTemplateError("존재하지 않는 template 입니다.",  { requestedTemplateId : data.templateId }); 
     }
 
-    const templateInfo = await deleteTemplate(numericTemplateId); // 여기부터 수정하기
+    const templateInfo = await deleteTemplate(data.templateId);
     if(templateInfo == 'inactive') { 
-        throw new InactiveTemplateError("이미 삭제된 template 입니다.", { requestedTemplateId : numericTemplateId });
+        throw new InactiveTemplateError("이미 삭제된 template 입니다.", { requestedTemplateId : data.templateId });
     } else if (!templateInfo) { // templateStatus === null인 경우
-        throw new NullStatusTemplateError("템플릿의 상태값이 null입니다. Null인 이유를 확인해주세요.", { requestedTemplateId : numericTemplateId });
+        throw new NullStatusTemplateError("템플릿의 상태값이 null입니다. Null인 이유를 확인해주세요.", { requestedTemplateId : data.templateId });
     }
     
     return responseFromTemplateDeletion(templateInfo);


### PR DESCRIPTION
이슈 #84 

[이전에 생성한 DTO 추가 이용]
- 템플릿 상세 정보 조회 API에서 만든 DTO (templateToDetailInfo) 재사용
(기능에 달라진 점 없음. 그냥 기존 parseInt을 DTO에서 하는 걸로 뺌.)