### PR TITLE
Feat/#123-이메일 인증(발송,검증) API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "multer": "^1.4.5-lts.1",
         "multer-s3": "^3.0.1",
         "mysql2": "^3.12.0",
+        "nodemailer": "^6.10.0",
         "passport": "^0.7.0",
         "swagger-autogen": "^2.23.7",
         "swagger-ui-express": "^5.0.1",
@@ -3142,6 +3143,15 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.0.tgz",
+      "integrity": "sha512-SQ3wZCExjeSatLE/HBaXS5vqUOQk6GtBdIIKxiFdmm01mOQZX/POJkO3SUX1wDiYcwUOJwT23scFSC9fY2H8IA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/nodemon": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "multer": "^1.4.5-lts.1",
     "multer-s3": "^3.0.1",
     "mysql2": "^3.12.0",
+    "nodemailer": "^6.10.0",
     "passport": "^0.7.0",
     "swagger-autogen": "^2.23.7",
     "swagger-ui-express": "^5.0.1",

--- a/src/dtos/auth.dto.js
+++ b/src/dtos/auth.dto.js
@@ -1,3 +1,5 @@
+import { EmailFormError, CodeFormError } from "../errors/auth.error.js";
+
 export const createdPostUserInfoDTO = (data) => {
   return {
     userId: data.id,
@@ -18,4 +20,29 @@ export const createdGetRefreshTokenDTO = (refreshToken) => {
   return {
     accessToken: refreshToken
   }
+};
+
+export const createdSendEmailDTO = (email) => {
+  if (!email || typeof email !== 'string' || !email.includes('@')) {
+    throw new EmailFormError("이메일은 '@'를 포함하는 문자열이어야 합니다.", { email });
+  }
+
+  return { 
+    email
+  };
+};
+
+export const createdVerifyEmailDTO = (email, code) => {
+  if (!email || typeof email !== 'string' || !email.includes('@')) {
+    throw new EmailFormError("이메일은 '@'를 포함하는 문자열이어야 합니다.", { email });
+  }
+
+  if (!code || typeof code !== 'string' || code.length !== 6) {
+    throw new CodeFormError("인증번호는 6자리 숫자입니다.", { code });
+  }
+
+  return { 
+    email,
+    code
+  };
 };

--- a/src/errors/auth.error.js
+++ b/src/errors/auth.error.js
@@ -72,3 +72,32 @@ export class InvalidTokenError extends Error {
         this.statusCode = 400;
     }
 }
+
+export class EmailFormError extends Error {
+    errorCode = "A018";
+    constructor(reason, data) {
+        super(reason);
+        this.reason = reason;
+        this.statusCode = 400;
+        this.data = data;
+    }
+}
+
+export class CodeFormError extends Error {
+    errorCode = "A019";
+    constructor(reason, data) {
+        super(reason);
+        this.reason = reason;
+        this.statusCode = 400;
+        this.data = data;
+    }
+}
+
+export class CodeNotValidateError extends Error {
+    errorCode = "A020";
+    constructor(reason) {
+        super(reason);
+        this.reason = reason;
+        this.statusCode = 400;
+    }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ import {handlerCreateTemplateLike, handlerGetTempleteView ,handlePopularTemplate
 import { handleViewAllPosts } from "./controllers/post.controller.js";
 import { handleDetailTemplateInfoLoad, handleTemplateDelete, handleTemplateCreateAndModify, handleGetTemplateFile } from "./controllers/template.controller.js";
 import { handleGetPostLiked } from "./controllers/post.controller.js";
-import { handleSignUp, handleLogin, handlecheckEmail, handleTokenRefresh } from "./controllers/auth.controller.js";
+import { handleSignUp, handleLogin, handlecheckEmail, handleTokenRefresh, handlesendEmail } from "./controllers/auth.controller.js";
 import { authenticateJWT } from "./auth.middleware.js";
 import { imageUploader } from "../middleware.js";
 
@@ -122,8 +122,11 @@ app.post('/posts/:postId/scrapts',authenticateJWT, handlerPostScrap);
 //게시물 검색 API
 app.get('/posts/search',handlerPostSearch);
 
-//이메일 인증 API
-app.get('/users/checkEmail', handlecheckEmail);
+//인증번호 발송 API
+app.post('/users/sendEmail', handlesendEmail);
+
+//인증번호 검증 API
+app.post('/users/checkEmail', handlecheckEmail);
 
 //회원가입 API
 app.post('/users/signup', handleSignUp);


### PR DESCRIPTION
nodemailer 라이브러리로 이메일 인증 구현

인증 호스트는 네이버 smtp 주소로 하였고 따로 Bemine 네이버 계정을 생성하여 구현

기능 특성상 인증번호 발송, 인증번호 검증 API를 한 브랜치에서 한 번에 구현