### PR TITLE
Feat: (로그인 전/후) 템플릿 목록 조회

### DIFF
--- a/src/controllers/template.controller.js
+++ b/src/controllers/template.controller.js
@@ -1,6 +1,6 @@
 import { StatusCodes } from "http-status-codes";
-import { detailTemplateInfoLoad, templateDeletion , templateFileInfo , getPopularTemplates, allTemplatesInfoLoad } from "../services/template.service.js";
-import { templateToDetailInfo, templateToFileInfo, postToAllTemplates } from "../dtos/template.dto.js";
+import { detailTemplateInfoLoad, templateDeletion , templateFileInfo , getPopularTemplates, allTemplatesInfoLoad, allTemplatesInfoLoadLoggedIn } from "../services/template.service.js";
+import { templateToDetailInfo, templateToFileInfo, postToAllTemplates, postToAllTemplatesLoggedIn } from "../dtos/template.dto.js";
 
 // 템플릿 상세 정보 불러오기 요청
 export const handleDetailTemplateInfoLoad = async (req, res, next) => {
@@ -627,5 +627,111 @@ export const handleViewAllTemplates = async(req, res, next) => {
 
 // 템플릿 목록 조회 (로그인 후)
 export const handleViewAllTemplatesLoggedIn = async(req, res, next) => {
+/* 
+    #swagger.summary = '템플릿 목록 조회 API (로그인 후)';
+    #swagger.tags = ['Template']
+    #swagger.parameters: [
+    { in: "query",
+        name: "categoryId",
+        schema: { type: "integer" },
+        description: "카테고리 ID",
+        required: false,
+    }
+    ]
+    #swagger.parameters: [
+    { in: "query",
+        name: "offset",
+        schema: { type: "integer" },
+        description: "offset (기본값: 0)",
+        required: false,
+    }
+    ]
+    #swagger.parameters: [
+    { in: "query",
+        name: "limit",
+        schema: { type: "integer" },
+        description: "limit (기본값: 20)",
+        required: false,
+    }
+    ]
+    #swagger.description = '로그인 후 템플릿 목록 조회를 하는 API입니다. (로그인 후에는 사용자에 대한 템플릿 좋아요 여부를 볼 수 있음)'
+    #swagger.responses[200] = {
+        description: "로그인 후 템플릿 목록 조회 성공 응답",
+        content: {
+            "application/json": {
+                schema: {
+                    type: "object",
+                    properties: {
+                        resultType: { type: "string", example: "SUCCESS" },
+                        error: { type: "object", nullable: true, example: null },
+                        success: {
+                            type: "object",
+                            properties: {
+                                data: {
+                                    type: "array",
+                                    items: {
+                                        type: "object",
+                                        properties: {
+                                            postCreatedAt: { type: "string", format: "date", example: "2025-01-10T00:41:23.000Z" },
+                                            postId: { type: "number", example: 100 },
+                                            title: { type: "string", example: "Template Title 100" },
+                                            thumbnail: { type: "string", example: "https://example.com/pictures/pic100.jpg"},
+                                            authorId: { type: "number", example: 5 },
+                                            authorName: { type: "string", example: "Eve" },
+                                            categoryId: { type: "number", example: 4 },
+                                            categoryName: { type: "string", example: "바이럴 마케터" },
+                                            likedStatus: { type: "boolean", example: true },
+                                        }
+                                    }
+                                },
+                                pagination: {
+                                    type: "object", 
+                                    properties: {
+                                        cursor: { type: "number", nullable: true }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    #swagger.responses[400] = {
+        description: "로그인 후 템플릿 목록 조회 실패 응답. (추가적인 실패 응답 예시는 노션 API 명세서를 참고해주세요)",
+        content: {
+            "application/json": {
+                schema: {
+                    type: "object",
+                    properties: {
+                        resultType: { type: "string", example: "FAIL" },
+                        error: {
+                            type: "object",
+                            properties: {
+                                errorCode: { type: "string", example: "T26" },
+                                reason: { type: "string", example: "유효하지 않은 categoryId 입니다." },
+                                data: {
+                                    type: "object",
+                                    properties: {
+                                        requestedCategoryId: { type: "number", example: -1 }
+                                    }
+                                }
+                            }
+                        },
+                        success: { type: "object", nullable: true, example: null }
+                    }
+                }
+            }
+        }
+    }
+*/
+    try {
+        console.log("\n템플릿 목록 조회를 요청했습니다! (로그인 후)");
 
+        const posts = await allTemplatesInfoLoadLoggedIn(postToAllTemplatesLoggedIn(req.user, req.query));
+
+        res.status(StatusCodes.OK).success(posts);
+    } catch (error) {
+        next(error);
+    }
 };

--- a/src/controllers/template.controller.js
+++ b/src/controllers/template.controller.js
@@ -1,6 +1,6 @@
 import { StatusCodes } from "http-status-codes";
-import { detailTemplateInfoLoad, templateDeletion , templateFileInfo , getPopularTemplates} from "../services/template.service.js";
-import { templateToDetailInfo, templateToFileInfo } from "../dtos/template.dto.js";
+import { detailTemplateInfoLoad, templateDeletion , templateFileInfo , getPopularTemplates, allTemplatesInfoLoad } from "../services/template.service.js";
+import { templateToDetailInfo, templateToFileInfo, postToAllTemplates } from "../dtos/template.dto.js";
 
 // 템플릿 상세 정보 불러오기 요청
 export const handleDetailTemplateInfoLoad = async (req, res, next) => {
@@ -510,4 +510,122 @@ export const handlePopularTemplates = async (req, res, next) => {
     } catch (error) {
         next(error);
     }
+};
+
+// 템플릿 목록 조회 (로그인 전)
+export const handleViewAllTemplates = async(req, res, next) => {
+    /* 
+    #swagger.summary = '템플릿 목록 조회 API (로그인 전)';
+    #swagger.tags = ['Template']
+    #swagger.parameters: [
+    { in: "query",
+        name: "categoryId",
+        schema: { type: "integer" },
+        description: "카테고리 ID",
+        required: false,
+    }
+    ]
+    #swagger.parameters: [
+    { in: "query",
+        name: "offset",
+        schema: { type: "integer" },
+        description: "offset (기본값: 0)",
+        required: false,
+    }
+    ]
+    #swagger.parameters: [
+    { in: "query",
+        name: "limit",
+        schema: { type: "integer" },
+        description: "limit (기본값: 20)",
+        required: false,
+    }
+    ]
+    #swagger.description = '로그인 전 템플릿 목록을 조회를 하는 API입니다. (로그인 전에는 템플릿 좋아요 여부를 볼 수 없음)'
+    #swagger.security = [{
+        "bearerAuth": []
+    }]
+    #swagger.responses[200] = {
+        description: "로그인 전 템플릿 목록 조회 성공 응답",
+        content: {
+            "application/json": {
+                schema: {
+                    type: "object",
+                    properties: {
+                        resultType: { type: "string", example: "SUCCESS" },
+                        error: { type: "object", nullable: true, example: null },
+                        success: {
+                            type: "object",
+                            properties: {
+                                data: {
+                                    type: "array",
+                                    items: {
+                                        type: "object",
+                                        properties: {
+                                            templateCreatedAt: { type: "string", format: "date", example: "2025-01-10T00:41:23.000Z" },
+                                            templateId: { type: "number", example: 100 },
+                                            title: { type: "string", example: "Template Title 100" },
+                                            thumbnail: { type: "string", example: "https://example.com/pictures/pic100.jpg"},
+                                            authorId: { type: "number", example: 5 },
+                                            authorName: { type: "string", example: "Eve" },
+                                            categoryId: { type: "number", example: 4 },
+                                            categoryName: { type: "string", example: "바이럴 마케터" },
+                                        }
+                                    }
+                                },
+                                pagination: {
+                                    type: "object", 
+                                    properties: {
+                                        cursor: { type: "number", nullable: true }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    #swagger.responses[400] = {
+        description: "로그인 전 템플릿 목록 조회 실패 응답. (추가적인 실패 응답 예시는 노션 API 명세서를 참고해주세요)",
+        content: {
+            "application/json": {
+                schema: {
+                    type: "object",
+                    properties: {
+                        resultType: { type: "string", example: "FAIL" },
+                        error: {
+                            type: "object",
+                            properties: {
+                                errorCode: { type: "string", example: "T26" },
+                                reason: { type: "string", example: "유효하지 않은 categoryId 입니다." },
+                                data: {
+                                    type: "object",
+                                    properties: {
+                                        requestedTemplateId: { type: "number", example: -1 }
+                                    }
+                                }
+                            }
+                        },
+                        success: { type: "object", nullable: true, example: null }
+                    }
+                }
+            }
+        }
+    }
+     */
+    try {
+        console.log("\n템플릿 목록 조회를 요청했습니다! (로그인 전)");
+
+        const posts = await allTemplatesInfoLoad(postToAllTemplates(req.query));
+
+        res.status(StatusCodes.OK).success(posts);
+    } catch (error) {
+        next(error);
+    }
+};
+
+// 템플릿 목록 조회 (로그인 후)
+export const handleViewAllTemplatesLoggedIn = async(req, res, next) => {
+
 };

--- a/src/dtos/template.dto.js
+++ b/src/dtos/template.dto.js
@@ -87,3 +87,32 @@ export const responseFromAllTemplates = (templates) => {
         }
     });
 }
+
+// 템플릿 목록 조회 (로그인 후) (controller->service)
+export const postToAllTemplatesLoggedIn = (user, query) => {
+    return{
+        userId: parseInt(user.userId),
+        categoryId: (query.categoryId == undefined ? undefined : parseInt(query.categoryId)),
+        offset: (query.offset === undefined ? 0 : parseInt(query.offset)), // 기본값 부여
+        limit: (query.limit === undefined ? 20 : parseInt(query.limit)) // 기본값 부여
+    }
+}
+
+// 게시물 전체 조회 (로그인 후) (controller->service)
+export const responseFromAllTemplatesLoggedIn = (templates) => {
+    return templates.map(template => {
+        const templateCreatedAt = new Date(template.template_created_at);
+
+        return {
+            templateCreatedAt,
+            templateId: template.template_id,
+            title: template.title,
+            thumbnail: template.thumbnail,
+            authorId: template.author_id,
+            authorName: template.author_name,
+            categoryId: template.category_id,
+            categoryName: template.category_name,
+            likedStatus: template.liked_status === null ? false : Boolean(template.liked_status), // liked_template 테이블에 없는 포스트는 null이므로 false으로 처리
+        }
+    });
+}

--- a/src/dtos/template.dto.js
+++ b/src/dtos/template.dto.js
@@ -60,3 +60,30 @@ export const responsePopularTemplates = (templates) => {
         thumbnail: template.thumbnail
     }));
 };
+
+// 템플릿 목록 조회 (로그인 전) (controller->service)
+export const postToAllTemplates = (query) => {
+    return{
+        categoryId: (query.categoryId == undefined ? undefined : parseInt(query.categoryId)),
+        offset: (query.offset === undefined ? 0 : parseInt(query.offset)), // 기본값 부여
+        limit: (query.limit === undefined ? 20 : parseInt(query.limit)) // 기본값 부여
+    }
+}
+
+// 게시물 전체 조회 (로그인 전) (controller->service)
+export const responseFromAllTemplates = (templates) => {
+    return templates.map(template => {
+        const templateCreatedAt = new Date(template.template_created_at);
+
+        return {
+            templateCreatedAt,
+            templateId: template.template_id,
+            title: template.title,
+            thumbnail: template.thumbnail,
+            authorId: template.author_id,
+            authorName: template.author_name,
+            categoryId: template.category_id,
+            categoryName: template.category_name
+        }
+    });
+}

--- a/src/errors/template.error.js
+++ b/src/errors/template.error.js
@@ -97,6 +97,7 @@ export class InvalidLimitError extends Error {
         super(reason);
         this.reason = reason;
         this.data = data;
+        this.statusCode = 400;
     }
 }
 
@@ -107,5 +108,6 @@ export class NonexistentCategoryIdError extends Error {
         super(reason);
         this.reason = reason;
         this.data = data;
+        this.statusCode = 400;
     }
 }

--- a/src/errors/template.error.js
+++ b/src/errors/template.error.js
@@ -50,7 +50,7 @@ export class DatabaseConnectionError extends Error {
 
 // userId와 templateId가 매칭되는 템플릿 좋아요 정보가 존재하지 않을 때
 export class NonexistentTemplateLike extends Error {
-    errorCode = "TL24";
+    errorCode = "T24";
     constructor(reason, data) {
         super(reason);
         this.reason = reason;
@@ -60,7 +60,49 @@ export class NonexistentTemplateLike extends Error {
 
 // user가 templateId에 좋아요를 한 status null일 때
 export class NullTemplateLike extends Error {
-    errorCode = "TL25";
+    errorCode = "T25";
+    constructor(reason, data) {
+        super(reason);
+        this.reason = reason;
+        this.data = data;
+    }
+}
+
+// 유효하지 않은 categoryId 에러
+export class InvalidCategoryIdError extends Error {
+    errorCode = "T26";
+    constructor(reason, data) {
+        super(reason);
+        this.reason = reason;
+        this.statusCode = 400;
+        this.data = data;
+    }
+}
+
+// 유효하지 않은 offset 에러
+export class InvalidOffsetError extends Error {
+    errorCode = "T27";
+    constructor(reason, data) {
+        super(reason);
+        this.reason = reason;
+        this.statusCode = 400;
+        this.data = data;
+    }
+}
+
+// 유효하지 않은 limit 에러
+export class InvalidLimitError extends Error {
+    errorCode = "T28";
+    constructor(reason, data) {
+        super(reason);
+        this.reason = reason;
+        this.data = data;
+    }
+}
+
+// 존재하지 않는 categoryId 에러
+export class NonexistentCategoryIdError extends Error {
+    errorCode = "T29";
     constructor(reason, data) {
         super(reason);
         this.reason = reason;

--- a/src/index.js
+++ b/src/index.js
@@ -177,7 +177,7 @@ app.get('/templates/:templateId/view', authenticateJWT, handleGetTemplateFile);
 app.get('/templates', handleViewAllTemplates);
 
 // 템플릿 목록 조회 API (로그인 후)
-app.get('/templates/loggedIn', authenticateJWT, handleViewAllTemplatesLoggedIn);
+app.get('/user/templates', authenticateJWT, handleViewAllTemplatesLoggedIn);
 
 //게시글 작성 API 
 app.post('/posts/write', authenticateJWT, handlePostWrite );

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ import swaggerAutogen from "swagger-autogen";
 import { handleOtherPost, handlerGetUserPost, handlerPostLike, handlerPostScrap, handlerPostSearch,getPostDetail ,handlePostWrite, handlePostDelete } from "./controllers/post.controller.js";
 import {handlerGetUserHistory, handlerPatchMyProfile} from "./controllers/user.controller.js";
 import {handlerGetRecentPost, handlerGetScrapPost, } from "./controllers/post.controller.js";
-import {handlerCreateTemplateLike, handlerGetTempleteView ,handlePopularTemplates } from "./controllers/template.controller.js";
+import {handlerCreateTemplateLike, handlerGetTempleteView ,handlePopularTemplates, handleViewAllTemplates, handleViewAllTemplatesLoggedIn } from "./controllers/template.controller.js";
 import { handleViewAllPosts } from "./controllers/post.controller.js";
 import { handleDetailTemplateInfoLoad, handleTemplateDelete, handleTemplateCreateAndModify, handleGetTemplateFile } from "./controllers/template.controller.js";
 import { handleGetPostLiked } from "./controllers/post.controller.js";
@@ -173,8 +173,11 @@ app.put('/templates/:templateId', handleTemplateCreateAndModify);
 // 템플릿 파일 조회 API
 app.get('/templates/:templateId/view', authenticateJWT, handleGetTemplateFile);
 
+// 템플릿 목록 조회 API (로그인 전)
+app.get('/templates', handleViewAllTemplates);
 
-
+// 템플릿 목록 조회 API (로그인 후)
+app.get('/templates/loggedIn', authenticateJWT, handleViewAllTemplatesLoggedIn);
 
 //게시글 작성 API 
 app.post('/posts/write', authenticateJWT, handlePostWrite );

--- a/src/repositories/template.repository.js
+++ b/src/repositories/template.repository.js
@@ -131,3 +131,60 @@ export const findPopularTemplates = async () => {
       conn.release();
   }
 };
+
+// 템플릿 목록 조회 (정보 얻기-로그인 전)
+export const getAllTemplatesInfo = async (categoryId, offset, limit) => {
+  const conn = await pool.getConnection();
+  try {
+      let templates;
+
+      // 기본 쿼리 정의
+      const baseQuery = `
+          SELECT 
+              t.created_at AS template_created_at,
+              t.id AS template_id,
+              t.title,
+              t.thumbnail,
+              u.id AS author_id,
+              u.name AS author_name
+          FROM template AS t
+          LEFT JOIN user AS u ON t.user_id = u.id`; 
+          // !! SELECT c.id, c.name은 ERD 변경 후 추가 예정
+          // !! LEFT JOIN category는 ERD 변경 후 추가 예정
+
+      // 카테고리가 명시되지 않은 경우
+      if (categoryId === undefined) {
+          [templates] = await conn.query(
+              `${baseQuery}
+              WHERE t.status = 'active'
+              ORDER BY t.created_at DESC
+              LIMIT ? OFFSET ?`, 
+              [limit, offset]
+          );
+      } else { // 카테고리가 명시된 경우
+          const [categoryCheck] = await conn.query(
+              `SELECT 1 FROM category WHERE id = ? LIMIT 1`,
+              [categoryId]
+          );
+          if (categoryCheck.length === 0) {
+              return null;
+          }
+
+          [templates] = await conn.query(
+              `${baseQuery}
+              WHERE t.status = 'active' AND t.category_id = ?
+              ORDER BY t.created_at DESC
+              LIMIT ? OFFSET ?`, 
+              [categoryId, limit, offset]
+          );
+      }
+
+      return templates;
+  } catch (err) {
+      throw new Error (
+          `템플릿 목록 조회 중에 오류가 발생했어요. 요청 파라미터를 확인해주세요. (${err})`
+        );
+  } finally {
+      conn.release();
+  }
+}

--- a/src/repositories/template.repository.js
+++ b/src/repositories/template.repository.js
@@ -187,4 +187,63 @@ export const getAllTemplatesInfo = async (categoryId, offset, limit) => {
   } finally {
       conn.release();
   }
-}
+};
+
+// 템플릿 목록 조회 (정보 얻기-로그인 후)
+export const getAllTemplatesInfoLoggedIn = async (userId, categoryId, offset, limit) => {
+  const conn = await pool.getConnection();
+  try {
+      let templates;
+
+      // 기본 쿼리 정의
+      const baseQuery = `
+          SELECT 
+              t.created_at AS template_created_at,
+              t.id AS template_id,
+              t.title,
+              t.thumbnail,
+              u.id AS author_id,
+              u.name AS author_name,
+              lt.status AS liked_status
+          FROM template AS t
+          LEFT JOIN user AS u ON t.user_id = u.id
+          LEFT JOIN liked_template AS lt ON t.id = lt.template_id AND lt.user_id = ? AND lt.status = true`; 
+          // !! SELECT c.id, c.name은 ERD 변경 후 추가 예정
+          // !! LEFT JOIN category는 ERD 변경 후 추가 예정
+
+      // 카테고리가 명시되지 않은 경우
+      if (categoryId === undefined) {
+          [templates] = await conn.query(
+              `${baseQuery}
+              WHERE t.status = 'active'
+              ORDER BY t.created_at DESC
+              LIMIT ? OFFSET ?`, 
+              [userId, limit, offset]
+          );
+      } else { // 카테고리가 명시된 경우
+          const [categoryCheck] = await conn.query(
+              `SELECT 1 FROM category WHERE id = ? LIMIT 1`,
+              [categoryId]
+          );
+          if (categoryCheck.length === 0) {
+              return null;
+          }
+
+          [templates] = await conn.query(
+              `${baseQuery}
+              WHERE t.status = 'active' AND t.category_id = ?
+              ORDER BY t.created_at DESC
+              LIMIT ? OFFSET ?`, 
+              [userId, categoryId, limit, offset]
+          );
+      }
+
+      return templates;
+  } catch (err) {
+      throw new Error (
+          `템플릿 목록 조회 중에 오류가 발생했어요. 요청 파라미터를 확인해주세요. (${err})`
+        );
+  } finally {
+      conn.release();
+  }
+};

--- a/src/services/template.service.js
+++ b/src/services/template.service.js
@@ -1,6 +1,6 @@
-import {  responseFromTemplateDeletion, responseFromTemplateAndLike, responsePopularTemplates, responseFromDetailInfo, responseFromAllTemplates } from "../dtos/template.dto.js";
+import {  responseFromTemplateDeletion, responseFromTemplateAndLike, responsePopularTemplates, responseFromDetailInfo, responseFromAllTemplates, responseFromAllTemplatesLoggedIn } from "../dtos/template.dto.js";
 import { InvalidTemplateIdError, NonexistentTemplateError, InactiveTemplateError, NullStatusTemplateError, NonexistentTemplateLike, NullTemplateLike, InvalidCategoryIdError, InvalidOffsetError, InvalidLimitError, NonexistentCategoryIdError } from "../errors/template.error.js";
-import { checkTemplateExists, getTemplateFileInfo, deleteTemplate, getDetailTemplateInfo , findPopularTemplates, getAllTemplatesInfo } from "../repositories/template.repository.js";
+import { checkTemplateExists, getTemplateFileInfo, deleteTemplate, getDetailTemplateInfo , findPopularTemplates, getAllTemplatesInfo, getAllTemplatesInfoLoggedIn } from "../repositories/template.repository.js";
 
 // 템플릿 상세 정보 불러오기 
 export const detailTemplateInfoLoad = async (data) => { 
@@ -86,4 +86,27 @@ export const allTemplatesInfoLoad = async (data) => {
     }
 
     return responseFromAllTemplates(allTemplatesInfo);
+}
+
+// 템플릿 목록 조회 (로그인 후)
+export const allTemplatesInfoLoadLoggedIn = async (data) => {
+    if (data.categoryId === undefined) {}
+    else if (isNaN(data.categoryId) || data.categoryId <= 0) {
+        throw new InvalidCategoryIdError("유효하지 않은 categoryId 입니다.", data.categoryId);
+    }
+    if (data.offset === undefined) {}
+    else if (isNaN(data.offset) || data.offset < 0) {
+        throw new InvalidOffsetError("유효하지 않은 offset 입니다.", data.offset);
+    }
+    if (data.limit === undefined) {}
+    else if (isNaN(data.limit) || data.limit <= 0) {
+        throw new InvalidLimitError("유효하지 않은 limit 입니다.", data.limit);
+    }
+
+    const allTemplatesInfo = await getAllTemplatesInfoLoggedIn(data.userId, data.categoryId, data.offset, data.limit);
+    if (allTemplatesInfo === null){
+        throw new NonexistentCategoryIdError("존재하지 않는 categoryId 입니다.", data.categoryId);
+    }
+
+    return responseFromAllTemplatesLoggedIn(allTemplatesInfo);
 }

--- a/src/services/template.service.js
+++ b/src/services/template.service.js
@@ -1,6 +1,6 @@
-import {  responseFromTemplateDeletion, responseFromTemplateAndLike, responsePopularTemplates, responseFromDetailInfo } from "../dtos/template.dto.js";
-import { InvalidTemplateIdError, NonexistentTemplateError, InactiveTemplateError, NullStatusTemplateError, NonexistentTemplateLike, NullTemplateLike } from "../errors/template.error.js";
-import { checkTemplateExists, getTemplateFileInfo, deleteTemplate, getDetailTemplateInfo , findPopularTemplates } from "../repositories/template.repository.js";
+import {  responseFromTemplateDeletion, responseFromTemplateAndLike, responsePopularTemplates, responseFromDetailInfo, responseFromAllTemplates } from "../dtos/template.dto.js";
+import { InvalidTemplateIdError, NonexistentTemplateError, InactiveTemplateError, NullStatusTemplateError, NonexistentTemplateLike, NullTemplateLike, InvalidCategoryIdError, InvalidOffsetError, InvalidLimitError, NonexistentCategoryIdError } from "../errors/template.error.js";
+import { checkTemplateExists, getTemplateFileInfo, deleteTemplate, getDetailTemplateInfo , findPopularTemplates, getAllTemplatesInfo } from "../repositories/template.repository.js";
 
 // 템플릿 상세 정보 불러오기 
 export const detailTemplateInfoLoad = async (data) => { 
@@ -64,3 +64,26 @@ export const getPopularTemplates = async () => {
     const templates = await findPopularTemplates();
     return responsePopularTemplates(templates);
 };
+
+// 템플릿 목록 조회 (로그인 전)
+export const allTemplatesInfoLoad = async (data) => {
+    if (data.categoryId === undefined) {}
+    else if (isNaN(data.categoryId) || data.categoryId <= 0) {
+        throw new InvalidCategoryIdError("유효하지 않은 categoryId 입니다.", data.categoryId);
+    }
+    if (data.offset === undefined) {}
+    else if (isNaN(data.offset) || data.offset < 0) {
+        throw new InvalidOffsetError("유효하지 않은 offset 입니다.", data.offset);
+    }
+    if (data.limit === undefined) {}
+    else if (isNaN(data.limit) || data.limit <= 0) {
+        throw new InvalidLimitError("유효하지 않은 limit 입니다.", data.limit);
+    }
+
+    const allTemplatesInfo = await getAllTemplatesInfo(data.categoryId, data.offset, data.limit);
+    if (allTemplatesInfo === null){
+        throw new NonexistentCategoryIdError("존재하지 않는 categoryId 입니다.", data.categoryId);
+    }
+
+    return responseFromAllTemplates(allTemplatesInfo);
+}


### PR DESCRIPTION
이것도 한 API로 만들기 실패.. (그럴려면 auth.middleware.js에서 userId가 null인 값이 될 수 있도록 허용해야 해서 복잡함)

## 내용
템플릿 목록 조회 api (로그인 전)

템플릿 목록 조회 api (로그인 후)
- api endpoint는 템플릿 단일 조회 API( GET /template/{templateId})랑 충돌나서 /user로 시작하도록 함. 

swagger 정리