### PR TITLE
Feat: (로그인 전/후) 게시물 전체 조회 --v2

### DIFF
--- a/src/controllers/post.controller.js
+++ b/src/controllers/post.controller.js
@@ -1,6 +1,6 @@
 import { StatusCodes } from "http-status-codes";
-import { getOtherPost, getPostDetailWithLikeStatus } from "../services/post.service.js";
-import { postToRecent, postToScrap } from "../dtos/post.dto.js";
+import { getOtherPost, getPostDetailWithLikeStatus, allPostsInfoLoad, allPostsInfoLoadLoggedIn } from "../services/post.service.js";
+import { postToRecent, postToScrap, postToAllPosts, postToAllPostsLoggedIn } from "../dtos/post.dto.js";
 import { createUserLike, createUserScrap, getSearchedPostsList, RecentViewPosts, ScrapPosts, createOrUpdatePost,deletePost } from "../services/post.service.js";
 import { imageUploader, deleteImage } from '../../middleware.js';
 
@@ -351,14 +351,41 @@ export const handlerGetScrapPost = async (req, res) => {
   res.status(StatusCodes.OK).success(posts)
 }
 
-// // 게시물 전체 조회 요청
+// 게시물 전체 조회 요청 (로그인 전)
 export const handleViewAllPosts = async (req, res, next) => {
   /* 
-  #swagger.summary = '게시물 전체 조회 API';
-  #swagger.tags = ['Get']
-  #swagger.description = '게시물 전체 조회를 하는 API입니다.'
+  #swagger.summary = '게시물 전체 조회 API (로그인 전)';
+  #swagger.tags = ['Post']
+  #swagger.parameters: [
+    { in: "query",
+      name: "categoryId",
+      schema: { type: "integer" },
+      description: "카테고리 ID",
+      required: false,
+    }
+  ]
+  #swagger.parameters: [
+    { in: "query",
+      name: "offset",
+      schema: { type: "integer" },
+      description: "offset (기본값: 0)",
+      required: false,
+    }
+  ]
+  #swagger.parameters: [
+    { in: "query",
+      name: "limit",
+      schema: { type: "integer" },
+      description: "limit (기본값: 20)",
+      required: false,
+    }
+  ]
+  #swagger.description = '로그인 전 게시물 전체 조회를 하는 API입니다. (로그인 전에는 게시물 좋아요, 스크랩 여부를 볼 수 없음)'
+  #swagger.security = [{
+      "bearerAuth": []
+  }]
   #swagger.responses[200] = {
-      description: "게시물 전체 조회 성공 응답",
+      description: "로그인 전 게시물 전체 조회 성공 응답",
       content: {
           "application/json": {
               schema: {
@@ -374,14 +401,14 @@ export const handleViewAllPosts = async (req, res, next) => {
                                   items: {
                                       type: "object",
                                       properties: {
-                                          postId: { type: "number", example: 1 },
-                                          userId: { type: "number", example: 1 },
-                                          categoryId: { type: "number", example: 1 },
-                                          title: { type: "string", example: "Post Title 1" },
-                                          body: { type: "string", example: "Post Body 1" },
-                                          picture: { type: "string", example: "https://example.com/pictures/pic1.jpg"},
-                                          createdAt: { type: "string", format: "date", example: "2025-01-10T00:41:23.000Z" },
-                                          updatedAt: { type: "string", format: "date", example: "2025-01-10T00:41:23.000Z" }
+                                          postCreatedAt: { type: "string", format: "date", example: "2025-01-10T00:41:23.000Z" },
+                                          postId: { type: "number", example: 100 },
+                                          title: { type: "string", example: "Post Title 100" },
+                                          thumbnail: { type: "string", example: "https://example.com/pictures/pic100.jpg"},
+                                          authorId: { type: "number", example: 5 },
+                                          authorName: { type: "string", example: "Eve" },
+                                          categoryId: { type: "number", example: 4 },
+                                          categoryName: { type: "string", example: "바이럴 마케터" },
                                       }
                                   }
                               },
@@ -399,9 +426,7 @@ export const handleViewAllPosts = async (req, res, next) => {
       }
   }
   #swagger.responses[400] = {
-
-      description: "게시물 전체 조회 실패 응답",
-
+      description: "로그인 전 게시물 전체 조회 실패 응답. (추가적인 실패 응답 예시는 노션 API 명세서를 참고해주세요)",
       content: {
           "application/json": {
               schema: {
@@ -411,7 +436,7 @@ export const handleViewAllPosts = async (req, res, next) => {
                       error: {
                           type: "object",
                           properties: {
-                              errorCode: { type: "string", example: "P001" },
+                              errorCode: { type: "string", example: "P20" },
                               reason: { type: "string", example: "유효하지 않은 categoryId 입니다." },
                               data: {
                                   type: "object",
@@ -429,9 +454,125 @@ export const handleViewAllPosts = async (req, res, next) => {
   }
   */
   try {
+    console.log("\게시물 전체 조회를 요청했습니다! (로그인 전)");
 
+    const posts = await allPostsInfoLoad(postToAllPosts(req.query));
+
+    res.status(StatusCodes.OK).success(posts);
   } catch (error) {
-    next(error);
+      next(error);
+  }
+}
+
+// 게시물 전체 조회 요청 (로그인 후)
+export const handleViewAllPostsLoggedIn = async (req, res, next) => {
+  /* 
+    #swagger.summary = '게시물 전체 조회 API (로그인 후)';
+    #swagger.tags = ['Post']
+    #swagger.parameters: [
+      { in: "query",
+        name: "categoryId",
+        schema: { type: "integer" },
+        description: "카테고리 ID",
+        required: false,
+      }
+    ]
+    #swagger.parameters: [
+      { in: "query",
+        name: "offset",
+        schema: { type: "integer" },
+        description: "offset (기본값: 0)",
+        required: false,
+      }
+    ]
+    #swagger.parameters: [
+      { in: "query",
+        name: "limit",
+        schema: { type: "integer" },
+        description: "limit (기본값: 20)",
+        required: false,
+      }
+    ]
+    #swagger.description = '로그인 후 게시물 전체 조회를 하는 API입니다. (로그인 후에는 사용자에 대한 게시물 좋아요, 스크랩 여부를 볼 수 있음)'
+    #swagger.responses[200] = {
+        description: "로그인 후 게시물 전체 조회 성공 응답",
+        content: {
+            "application/json": {
+                schema: {
+                    type: "object",
+                    properties: {
+                        resultType: { type: "string", example: "SUCCESS" },
+                        error: { type: "object", nullable: true, example: null },
+                        success: {
+                            type: "object",
+                            properties: {
+                                data: {
+                                    type: "array",
+                                    items: {
+                                        type: "object",
+                                        properties: {
+                                            postCreatedAt: { type: "string", format: "date", example: "2025-01-10T00:41:23.000Z" },
+                                            postId: { type: "number", example: 100 },
+                                            title: { type: "string", example: "Post Title 100" },
+                                            thumbnail: { type: "string", example: "https://example.com/pictures/pic100.jpg"},
+                                            authorId: { type: "number", example: 5 },
+                                            authorName: { type: "string", example: "Eve" },
+                                            categoryId: { type: "number", example: 4 },
+                                            categoryName: { type: "string", example: "바이럴 마케터" },
+                                            likedStatus: { type: "boolean", example: true },
+                                            scrapStatus: { type: "boolean", example: false }
+                                        }
+                                    }
+                                },
+                                pagination: {
+                                    type: "object", 
+                                    properties: {
+                                        cursor: { type: "number", nullable: true }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    #swagger.responses[400] = {
+        description: "로그인 후 게시물 전체 조회 실패 응답. (추가적인 실패 응답 예시는 노션 API 명세서를 참고해주세요)",
+        content: {
+            "application/json": {
+                schema: {
+                    type: "object",
+                    properties: {
+                        resultType: { type: "string", example: "FAIL" },
+                        error: {
+                            type: "object",
+                            properties: {
+                                errorCode: { type: "string", example: "P20" },
+                                reason: { type: "string", example: "유효하지 않은 categoryId 입니다." },
+                                data: {
+                                    type: "object",
+                                    properties: {
+                                        requestedCategoryId: { type: "number", example: 0 }
+                                    }
+                                }
+                            }
+                        },
+                        success: { type: "object", nullable: true, example: null }
+                    }
+                }
+            }
+        }
+    }
+  */
+  try {
+    console.log("\게시물 전체 조회를 요청했습니다! (로그인 후)");
+
+    const posts = await allPostsInfoLoadLoggedIn(postToAllPostsLoggedIn(req.user, req.query));
+
+    res.status(StatusCodes.OK).success(posts);
+  } catch (error) {
+      next(error);
   }
 }
 

--- a/src/dtos/post.dto.js
+++ b/src/dtos/post.dto.js
@@ -69,3 +69,60 @@ export const createPostDetailDTO = (post, isLiked) => {
       liked: isLiked
   }
 };
+
+// 게시물 전체 조회 (로그인 전) (controller->service)
+export const postToAllPosts = (query) => {
+  return{
+    categoryId: (query.categoryId == undefined ? undefined : parseInt(query.categoryId)),
+    offset: (query.offset === undefined ? 0 : parseInt(query.offset)), // 기본값 부여
+    limit: (query.limit === undefined ? 20 : parseInt(query.limit)) // 기본값 부여
+  }
+}
+
+// 게시물 전체 조회 (로그인 후) (controller->service)
+export const postToAllPostsLoggedIn = (user, query) => {
+  return{
+    userId: parseInt(user.userId), // 로그인 전용
+    categoryId: (query.categoryId == undefined ? undefined : parseInt(query.categoryId)),
+    offset: (query.offset === undefined ? 0 : parseInt(query.offset)), // 기본값 부여
+    limit: (query.limit === undefined ? 20 : parseInt(query.limit)) // 기본값 부여
+  }
+}
+
+// 게시물 전체 조회 (로그인 전) (controller->service)
+export const responseFromAllPosts = (posts) => {
+  return posts.map(post => {
+    const postCreatedAt = new Date(post.post_created_at);
+
+    return {
+      postCreatedAt,
+      postId: post.post_id,
+      title: post.title,
+      thumbnail: post.thumbnail,
+      authorId: post.author_id,
+      authorName: post.author_name,
+      categoryId: post.category_id,
+      categoryName: post.category_name
+    }
+  });
+}
+
+// 게시물 전체 조회 (로그인 후) (controller->service)
+export const responseFromAllPostsLoggedIn = (posts) => {
+  return posts.map(post => {
+    const postCreatedAt = new Date(post.post_created_at);
+
+    return {
+      postCreatedAt,
+      postId: post.post_id,
+      title: post.title,
+      thumbnail: post.thumbnail,
+      authorId: post.author_id,
+      authorName: post.author_name,
+      categoryId: post.category_id,
+      categoryName: post.category_name,
+      likedStatus: post.liked_status === null ? false : Boolean(post.liked_status),  // liked_post 테이블에 없는 포스트는 null이므로 false으로 처리
+      scrapStatus: post.scrap_status === null ? false : Boolean(post.scrap_status),  // scrap_post 테이블에 없는 포스트는 null이므로 false으로 처리
+    }
+  });
+}

--- a/src/dtos/template.dto.js
+++ b/src/dtos/template.dto.js
@@ -15,7 +15,7 @@ export const responseFromDetailInfo = (templateInfo) => {
         userId: templateInfo.user_id || "",
         title: templateInfo.title || "",
         filePPT: templateInfo.file_ppt,
-        filePDF: templateInfo.file_ppt,
+        filePDF: templateInfo.file_pdf,
         fileShareState: templateInfo.file_share_state || "",
         thumbnail: templateInfo.thumbnail,
         createdAt,

--- a/src/errors/post.error.js
+++ b/src/errors/post.error.js
@@ -138,3 +138,46 @@ export class PostNotFoundError extends Error {
     }
 }
 
+// 유효하지 않은 categoryId 에러
+export class InvalidCategoryIdError extends Error {
+    errorCode = "P20";
+    constructor(reason, data) {
+        super(reason);
+        this.reason = reason;
+        this.statusCode = 400;
+        this.data = data;
+    }
+}
+
+// 유효하지 않은 offset 에러
+export class InvalidOffsetError extends Error {
+    errorCode = "P21";
+    constructor(reason, data) {
+        super(reason);
+        this.reason = reason;
+        this.statusCode = 400;
+        this.data = data;
+    }
+}
+
+// 유효하지 않은 limit 에러
+export class InvalidLimitError extends Error {
+    errorCode = "P22";
+    constructor(reason, data) {
+        super(reason);
+        this.reason = reason;
+        this.data = data;
+        this.statusCode = 400;
+    }
+}
+
+// 존재하지 않는 categoryId 에러
+export class NonexistentCategoryIdError extends Error {
+    errorCode = "P23";
+    constructor(reason, data) {
+        super(reason);
+        this.reason = reason;
+        this.data = data;
+        this.statusCode = 400;
+    }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ import { handleOtherPost, handlerGetUserPost, handlerPostLike, handlerPostScrap,
 import {handlerGetUserHistory, handlerPatchMyProfile} from "./controllers/user.controller.js";
 import {handlerGetRecentPost, handlerGetScrapPost, } from "./controllers/post.controller.js";
 import {handlerCreateTemplateLike, handlerGetTempleteView ,handlePopularTemplates } from "./controllers/template.controller.js";
-import { handleViewAllPosts } from "./controllers/post.controller.js";
+import { handleViewAllPosts, handleViewAllPostsLoggedIn } from "./controllers/post.controller.js";
 import { handleDetailTemplateInfoLoad, handleTemplateDelete, handleTemplateCreateAndModify, handleGetTemplateFile } from "./controllers/template.controller.js";
 import { handleGetPostLiked } from "./controllers/post.controller.js";
 import { handleSignUp, handleLogin, handlecheckEmail, handleTokenRefresh, handlesendEmail } from "./controllers/auth.controller.js";
@@ -110,8 +110,11 @@ app.get('/', (req, res) => {
 //메인페이지 좋아요 많은순 템플릿 출력
 app.get('/templates/popular',handlePopularTemplates);
 
-// 게시물 전체 조회 API
+// 게시물 전체 조회 API (로그인 전)
 app.get('/posts', handleViewAllPosts);
+
+// 게시물 전체 조회 API (로그인 후)
+app.get('/user/posts', authenticateJWT, handleViewAllPostsLoggedIn);
 
 //게시물 좋아요 누르기 API
 app.post('/posts/:postId/likes', authenticateJWT, handlerPostLike);

--- a/src/repositories/post.repository.js
+++ b/src/repositories/post.repository.js
@@ -254,3 +254,126 @@ export const createRecentViewPost = async (conn, userId, postId) => {
         );
     }
 };
+
+// 게시물 전체 조회 (정보 얻기-로그인 전)
+export const getAllPostsInfo = async (categoryId, offset, limit) => {
+    const conn = await pool.getConnection();
+    try {
+        let posts;
+
+        // 기본 쿼리 정의
+        const baseQuery = `
+            SELECT 
+                p.created_at AS post_created_at,
+                p.id AS post_id,
+                p.title,
+                p.thumbnail,
+                u.id AS author_id,
+                u.name AS author_name,
+                c.id AS category_id,
+                c.name AS category_name
+            FROM post AS p
+            LEFT JOIN category AS c ON p.category_id = c.id
+            LEFT JOIN user AS u ON p.user_id = u.id`;
+
+        // 카테고리가 명시되지 않은 경우
+        if (categoryId === undefined) {
+            [posts] = await conn.query(
+                `${baseQuery}
+                WHERE p.status = 'active'
+                ORDER BY p.created_at DESC
+                LIMIT ? OFFSET ?`, 
+                [limit, offset]
+            );
+        } else { // 카테고리가 명시된 경우
+            const [categoryCheck] = await conn.query(
+                `SELECT 1 FROM category WHERE id = ? LIMIT 1`,
+                [categoryId]
+            );
+            if (categoryCheck.length === 0) {
+                return null;
+            }
+
+            [posts] = await conn.query(
+                `${baseQuery}
+                WHERE p.status = 'active' AND p.category_id = ?
+                ORDER BY p.created_at DESC
+                LIMIT ? OFFSET ?`, 
+                [categoryId, limit, offset]
+            );
+        }
+
+        return posts;
+    } catch (err) {
+        throw new Error (
+            `게시물 전체 조회 중에 오류가 발생했어요. 요청 파라미터를 확인해주세요. (${err})`
+        );
+    } finally {
+        conn.release();
+    }
+}
+
+// 게시물 전체 조회 (정보 얻기-로그인 후)
+export const getAllPostsInfoLoggedIn = async (userId, categoryId, offset, limit) => {
+    const conn = await pool.getConnection();
+    try {
+        let posts;
+
+        // liked_post 테이블에서 user_id === userId이고 status === true인 경우, status도 같이 조회되도록 하기
+
+        // 기본 쿼리 정의
+        const baseQuery = `
+            SELECT 
+                p.created_at AS post_created_at,
+                p.id AS post_id,
+                p.title,
+                p.thumbnail,
+                u.id AS author_id,
+                u.name AS author_name,
+                c.id AS category_id,
+                c.name AS category_name,
+                lp.status AS liked_status,
+                sp.status AS scrap_status
+            FROM post AS p
+            LEFT JOIN category AS c ON p.category_id = c.id
+            LEFT JOIN user AS u ON p.user_id = u.id
+            LEFT JOIN liked_post AS lp ON p.id = lp.post_id AND lp.user_id = ? AND lp.status = true
+            LEFT JOIN scrap_post AS sp ON p.id = sp.post_id AND sp.user_id = ? AND sp.status = true`;
+
+        // 카테고리가 명시되지 않은 경우
+        if (categoryId === undefined) {
+            [posts] = await conn.query(
+                `${baseQuery}
+                WHERE p.status = 'active'
+                ORDER BY p.created_at DESC
+                LIMIT ? OFFSET ?`, 
+                [userId, userId, limit, offset]
+            );
+        } else { // 카테고리가 명시된 경우
+            const [categoryCheck] = await conn.query(
+                `SELECT 1 FROM category WHERE id = ? LIMIT 1`,
+                [categoryId]
+            );
+            if (categoryCheck.length === 0) {
+                return null;
+            }
+
+            [posts] = await conn.query(
+                `${baseQuery}
+                WHERE p.status = 'active' AND p.category_id = ?
+                ORDER BY p.created_at DESC
+                LIMIT ? OFFSET ?`, 
+                [userId, userId, categoryId, limit, offset]
+            );
+        }
+
+        return posts;
+
+    } catch (err) {
+        throw new Error (
+            `게시물 전체 조회 중에 오류가 발생했어요. 요청 파라미터를 확인해주세요. (${err})`
+        );
+    } finally {
+        conn.release();
+    }
+}

--- a/src/services/post.service.js
+++ b/src/services/post.service.js
@@ -5,18 +5,18 @@ import {
     responseFromScrapPost,
     responseFromSearchedPost
 } from "../dtos/post.dto.js";
-import { createdGetOtherPostDTO, createPostDetailDTO } from "../dtos/post.dto.js";
+import { createdGetOtherPostDTO, createPostDetailDTO, responseFromAllPosts, responseFromAllPostsLoggedIn } from "../dtos/post.dto.js";
 import {
     alreadyExistPostLike,
     alreadyExistPostScrap,
     NonExistUserError,
     NotFoundSearchedPost,
 
-    NotRecentPostsErrors, NotScrapPostsErrors, ContentRequiredError, TitleRequiredError, InvalidImageFormatError
+    NotRecentPostsErrors, NotScrapPostsErrors, ContentRequiredError, TitleRequiredError, InvalidImageFormatError, InvalidCategoryIdError, InvalidOffsetError, InvalidLimitError, NonexistentCategoryIdError
 } from "../errors/post.error.js";
 
 import { createUserPostLike, createUserPostScrap, getRecentPosts, getSearchPosts, findPostForDelete, updatePostStatus, getScrapPosts,getPostById,checkPostLiked } from "../repositories/post.repository.js";
-import { getUserOtherPost, createPost, updatePost } from "../repositories/post.repository.js";
+import { getUserOtherPost, createPost, updatePost, getAllPostsInfo, getAllPostsInfoLoggedIn } from "../repositories/post.repository.js";
 import { getUserInfo } from "../repositories/user.repository.js";
 import { pool } from "../db.config.js";
 import { NotExsistsUserError } from "../errors/user.error.js";
@@ -254,4 +254,50 @@ export const createOrUpdatePost = async (postData) => {
 } finally {
     conn.release();
 }
+}
+
+// 게시물 전체 조회 (로그인 전)
+export const allPostsInfoLoad = async (data) => {
+    if (data.categoryId === undefined) {}
+    else if (isNaN(data.categoryId) || data.categoryId <= 0) {
+        throw new InvalidCategoryIdError("유효하지 않은 categoryId 입니다.", data.categoryId);
+    }
+    if (data.offset === undefined) {}
+    else if (isNaN(data.offset) || data.offset < 0) {
+        throw new InvalidOffsetError("유효하지 않은 offset 입니다.", data.offset);
+    }
+    if (data.limit === undefined) {}
+    else if (isNaN(data.limit) || data.limit <= 0) {
+        throw new InvalidLimitError("유효하지 않은 limit 입니다.", data.limit);
+    }
+
+    const allPostsInfo = await getAllPostsInfo(data.categoryId, data.offset, data.limit);
+    if (allPostsInfo === null){
+        throw new NonexistentCategoryIdError("존재하지 않는 categoryId 입니다.", data.categoryId);
+    }
+
+    return responseFromAllPosts(allPostsInfo);
+}
+
+// 게시물 전체 조회 (로그인 후)
+export const allPostsInfoLoadLoggedIn = async (data) => {
+    if (data.categoryId === undefined) {}
+    else if (isNaN(data.categoryId) || data.categoryId <= 0) {
+        throw new InvalidCategoryIdError("유효하지 않은 categoryId 입니다.", { requestedcategoryId : data.categoryId} );
+    }
+    if (data.offset === undefined) {}
+    else if (isNaN(data.offset) || data.offset < 0) {
+        throw new InvalidOffsetError("유효하지 않은 offset 입니다.", data.offset);
+    }
+    if (data.limit === undefined) {}
+    else if (isNaN(data.limit) || data.limit <= 0) {
+        throw new InvalidLimitError("유효하지 않은 limit 입니다.", data.limit);
+    }
+
+    const allPostsInfo = await getAllPostsInfoLoggedIn(data.userId, data.categoryId, data.offset, data.limit);
+    if (allPostsInfo === null){
+        throw new NonexistentCategoryIdError("존재하지 않는 categoryId 입니다.", data.categoryId);
+    }
+
+    return responseFromAllPostsLoggedIn(allPostsInfo);
 }


### PR DESCRIPTION
기존 로컬 브랜치에서 수정하고 push하려다가 충돌 너무 나서 아예 새로 팠습니다.. 
아마 기존 브랜치에 엄청 예전 develop에서 따온거라 그런듯요.

## 내용
(로그인 전/후) 게시물 전체 조회 API 개발
- 한 API로 만들기 실패했습니다. (그럴려면 auth.middleware.js에서 userId가 null인 값이 될 수 있도록 허용해야 해서 복잡함)
- (NEW!) 로그인 후 api endpoint 변경시킴. (이유는 #135  참조 바람. 템플릿 목록 조회 api랑 개연성 맞춘다고 /user로 시작시킴)
- (NEW!) repository.js에서 post.status = 'active'인 경우도 고려해서 조회시키도록 함.

스웨거 수정