### PR TITLE
:recycle: [Refactor] N+1 최적화 완료

### DIFF
--- a/src/dtos/user.dto.js
+++ b/src/dtos/user.dto.js
@@ -12,6 +12,7 @@ export const userToHistory = (user) =>{
 
 // 연혁 조회 전송 DTO
 export const responseFromHistory = (data) =>{
+    console.log(data)
     return {
         userId: data.userId,
         history: data.history

--- a/src/repositories/post.repository.js
+++ b/src/repositories/post.repository.js
@@ -117,20 +117,23 @@ export const createUserPostScrap = async (userId, postId) => {
 
 // 최근 본 게시물 테이블에서 게시물 ID 조회
 export const getRecentPosts = async (userId)=>{
-    const posts = await prisma.recentViewPost.findMany({
-        where:{userId: userId},
+    const posts = await prisma.user.findUnique({
+        where:{id: userId},
         select:{
-            post:{
+            id: true,
+            recentViews:{
+                take:16,
+                orderBy:{createdAt: 'desc'},
                 select:{
-                    id: true,
-                    thumbnail: true
+                    post:{
+                        select:{
+                            id:true,
+                            thumbnail:true
+                        }
+                    }
                 }
             }
-        },
-        orderBy:{
-            createdAt: 'desc'
-        },
-        take: 16
+        }
     })
     return posts;
 }
@@ -150,20 +153,25 @@ export const getSearchPosts = async  (words)=> {
 
 // 스크랩한 게시물 조회
 export const getScrapPosts = async (data)=>{
-    const posts = await prisma.scrapPost.findMany({
-        where:{userId: data.userId, status: true},
+    const posts = await prisma.user.findUnique({
+        where:{id: data.userId},
         select:{
-            post:{
+            id: true,
+            scrapPosts:{
+                where:{ status: true},
+                take: 16,
+                orderBy:{createdAt: 'desc'},
                 select:{
-                    id: true,
-                    thumbnail: true
+                    post:{
+                        select:{
+                            id:true,
+                            thumbnail:true
+                        }
+                    }
                 }
             }
-        },
-        orderBy:{
-            createdAt: 'desc'
-        },
-        take: 16
+        }
+
     })
     return posts;
 }

--- a/src/repositories/user.repository.js
+++ b/src/repositories/user.repository.js
@@ -12,11 +12,15 @@ export const getUserInfo = async (data) =>{
 
 // 연혁 조회하기
 export const getUserHistory = async (data) => {
-    const history = await prisma.userHistory.findMany({
-        where: {userId: data.userId},
-        select:{
-            title: true,
-            body: true
+    const history = await prisma.user.findUnique({
+        where: {id: data.userId},
+        include: {
+            userHistories:{
+                select: {
+                    title: true,
+                    body: true
+                }
+            }
         }
     })
     return history;
@@ -28,6 +32,10 @@ export const patchUserProfile = async (data) => {
         where: {id: data.userId},
         data:{
             photo:data.photo
+        },
+        select:{
+            id: true,
+            photo: true
         }
     })
 
@@ -110,4 +118,42 @@ export const getUserProfile =async(data) =>{
 
 
     return user;
+}
+
+// 유저 프로필 사진 가져오기
+export const getUserPhoto = async(data) =>{
+    const userPhoto = await prisma.user.findUnique({
+        where: {id: data.userId},
+        select:{
+            photo: true
+        }
+    })
+
+    return userPhoto;
+}
+
+// 연혁 생성과 자기소개를 트랜잭션으로 묶어서 처리
+export const historyCreateAndUserIntroduction = async (data) =>{
+    const [history, user] = await prisma.$transaction([
+        prisma.userHistory.create({
+            data:{
+                userId: data.userId,
+                title: data.title,
+                body: data.body
+            },
+            select:{
+                id: true,
+                userId: true,
+                title: true,
+                body: true
+            }
+        }),
+        prisma.user.update({
+            where:{id : data.userId},
+            data:{introduction: data.introduction},
+            select: {introduction: true}
+        })
+    ]);
+
+    return {history,user}
 }

--- a/src/services/post.service.js
+++ b/src/services/post.service.js
@@ -13,7 +13,16 @@ import {
     NonExistUserError,
     NotFoundSearchedPost,
 
-    NotRecentPostsErrors, NotScrapPostsErrors, ContentRequiredError, TitleRequiredError, InvalidImageFormatError, InvalidCategoryIdError, InvalidOffsetError, InvalidLimitError, NonexistentCategoryIdError
+    NotRecentPostsErrors,
+    NotScrapPostsErrors,
+    ContentRequiredError,
+    TitleRequiredError,
+    InvalidImageFormatError,
+    InvalidCategoryIdError,
+    InvalidOffsetError,
+    InvalidLimitError,
+    NonexistentCategoryIdError,
+    PostNotFoundError
 } from "../errors/post.error.js";
 
 import { createUserPostLike, createUserPostScrap, getRecentPosts, getSearchPosts, findPostForDelete, updatePostStatus, getScrapPosts,getPostById,checkPostLiked, handleGetUserOwnPosts } from "../repositories/post.repository.js";
@@ -77,15 +86,14 @@ export const createUserScrap = async (userId, postId) => {
 
 // 최근 본 게시물 조회
 export const RecentViewPosts = async (data) => {
-    const recentPosts = await getRecentPosts(data.userId);
+    const results = await getRecentPosts(data.userId);
     const userId = data.userId
 
-    const confirm = await getUserInfo(data);
-
     // 존재하는 사용자인지 검사
-    if (confirm === null)
-        throw new NotExsistsUserError("유저가 존재하지 않음", data.userId)
+    if (!results)
+        throw new NotExsistsUserError("유저가 존재하지 않음", userId)
 
+    const recentPosts = results.recentViews;
 
     const posts = recentPosts.map(item => ({
         postId: item.post.id,
@@ -107,15 +115,14 @@ export const getSearchedPostsList = async (word) => {
 
 // 스크랩한 게시물 조회
 export const ScrapPosts = async (data) => {
-    const scrapPosts = await getScrapPosts(data);
+    const results = await getScrapPosts(data);
     const userId = data.userId
 
-    const confirm = await getUserInfo(data);
-
     // 존재하는 사용자인지 검사
-    if (confirm === null)
+    if (!results)
         throw new NotExsistsUserError("유저가 존재하지 않음", data.userId)
 
+    const scrapPosts = results.scrapPosts;
     const posts = scrapPosts.map(item => ({
         postId: item.post.id,
         url: item.post.thumbnail

--- a/src/services/user.service.js
+++ b/src/services/user.service.js
@@ -1,7 +1,7 @@
 import {
     createUserHistory,
     getUserHistory,
-    getUserInfo, getUserProfile,
+    getUserInfo, getUserPhoto, getUserProfile, historyCreateAndUserIntroduction,
     patchUserProfile,
     updateUserHistory, updateUserIntroduction
 } from "../repositories/user.repository.js";
@@ -16,23 +16,24 @@ import {deleteImage} from "../../middleware.js";
 
 // 연혁 조회하기
 export const userHistory = async (data) =>{
-    const confirm = await getUserInfo(data);
+    // 연혁 가져오기(user가 없으면 null, 연혁이 없으면 histories가 빈배열로 넘어옴)
+    const userHistoryInfo = await getUserHistory(data)
+
     // 존재하는 사용자인지 검사
-    if(confirm === null)
+    if(!userHistoryInfo)
         throw new NotExsistsUserError("존재하지 않는 사용자입니다.", data)
 
-    // 연혁 가져오기
-    const history = await getUserHistory(data)
-    const userId = data.userId
+    const userId = userHistoryInfo.id
+    const history = userHistoryInfo.userHistories;
     return responseFromHistory({userId, history});
 }
 
 // 유저 프로필 수정하기
 export const userProfileModify = async (data) => {
-    const confirm = await getUserInfo(data);
+    const confirm = await getUserPhoto(data);
 
     // 존재하는 사용자인지 검사
-    if(confirm === null)
+    if(!confirm)
         throw new NotExsistsUserError("존재하지 않는 사용자입니다.", data.userId)
 
     // 이전 이미지의 URL을 받음
@@ -40,7 +41,7 @@ export const userProfileModify = async (data) => {
 
     // 이전 이미지가 존재할 경우 삭제
     if(preProfile){
-        const responseDel = await deleteImage(preProfile)
+        await deleteImage(preProfile)
     }
 
     const updateUser = await patchUserProfile(data)
@@ -71,13 +72,9 @@ export const userHistoryCreate = async (data) => {
         throw new NotExsistsUserError("존재하지 않는 사용자입니다.", {userId: data.userId})
     }
 
-    const history = await createUserHistory(data);
-
-    const user = await updateUserIntroduction(data.userId, data.introduction)
+    const {history, user} = await historyCreateAndUserIntroduction(data);
     const introduction = user.introduction;
     return responseFromCreateHistory({history,introduction});
-
-
 }
 
 // 사용자 정보 조회


### PR DESCRIPTION
연혁 조회하기 
- getUserInfo 사용안함 join으로 묶어서 처리

유저 프로필 수정하기
- getUserInfo 대신 getUserPhoto를 사용하여 사진만 가져옴
- patchUserProfile -> userId, photo만 가져오게 수정

연혁생성
- 연혁 생성과 자기소개 업데이트를 하나의 트랜잭션으로 묶어서 처리
- 데이터 일관성 유지 가능 -> 하나라도 실패하면 모두 실패처리

최근본 게시물 조회
- getUserInfo 삭제 
- getRecentPosts에서 조인 사용하여 처리

스크랩한 게시물 조회 
- getUserInfo 삭제 
- getScrapPosts 조인 사용 