### PR TITLE
[Refactor] 게시물, 템플릿 별 총 좋아요 개수 집계 (메인페이지)

### DIFF
--- a/src/controllers/post.controller.js
+++ b/src/controllers/post.controller.js
@@ -378,6 +378,7 @@ export const handleViewAllPosts = async (req, res, next) => {
                                           authorName: { type: "string", example: "Eve" },
                                           categoryId: { type: "integer", example: 4 },
                                           categoryName: { type: "string", example: "바이럴 마케터" },
+                                          totalLikes: { type: "integer", example: 0}
                                       }
                                   }
                               },
@@ -489,7 +490,8 @@ export const handleViewAllPostsLoggedIn = async (req, res, next) => {
                                             categoryId: { type: "integer", example: 4 },
                                             categoryName: { type: "string", example: "바이럴 마케터" },
                                             likedStatus: { type: "boolean", example: true },
-                                            scrapStatus: { type: "boolean", example: false }
+                                            scrapStatus: { type: "boolean", example: false },
+                                            totalLikes: { type: "integer", example: 0}
                                         }
                                     }
                                 },

--- a/src/controllers/template.controller.js
+++ b/src/controllers/template.controller.js
@@ -804,7 +804,10 @@ export const handleViewAllTemplates = async(req, res, next) => {
                                             authorName: { type: "string", example: "Alice" },
                                             categoryId: { type: "integer", example: 1 },
                                             categoryName: { type: "string", example: "콘텐츠 마케터" },
-                                            surveyCount: { type: "integer", example: 0 },
+                                            surveyCountDesign: { type: "integer", example: 10 },
+                                            surveyCountCredible: { type: "integer", example: 0},
+                                            surveyCountUseful: { type: "integer", example: 0},
+                                            totalLikes: { type: "integer", exmaple: 0 }
                                         }
                                     }
                                 },
@@ -916,7 +919,10 @@ export const handleViewAllTemplatesLoggedIn = async(req, res, next) => {
                                             categoryId: { type: "integer", example: 1 },
                                             categoryName: { type: "string", example: "콘텐츠 마케터" },
                                             likedStatus: { type: "boolean", example: false },
-                                            surveyCount: { type: "integer", example: 0 },
+                                            surveyCountDesign: { type: "integer", example: 10 },
+                                            surveyCountCredible: { type: "integer", example: 0},
+                                            surveyCountUseful: { type: "integer", example: 0},
+                                            totalLikes: { type: "integer", exmaple: 0 }
                                         }
                                     }
                                 },

--- a/src/dtos/post.dto.js
+++ b/src/dtos/post.dto.js
@@ -128,7 +128,8 @@ export const responseFromAllPosts = (posts) => {
       authorId: post.author_id,
       authorName: post.author_name,
       categoryId: post.category_id,
-      categoryName: post.category_name
+      categoryName: post.category_name,
+      totalLikes: post.total_like_count
     }
   });
 }
@@ -149,6 +150,7 @@ export const responseFromAllPostsLoggedIn = (posts) => {
       categoryName: post.category_name,
       likedStatus: post.liked_status === null ? false : Boolean(post.liked_status),  // liked_post 테이블에 없는 포스트는 null이므로 false으로 처리
       scrapStatus: post.scrap_status === null ? false : Boolean(post.scrap_status),  // scrap_post 테이블에 없는 포스트는 null이므로 false으로 처리
+      totalLikes: post.total_like_count
     }
   });
 }

--- a/src/dtos/template.dto.js
+++ b/src/dtos/template.dto.js
@@ -159,6 +159,7 @@ export const responseFromAllTemplates = (templates) => {
             surveyCountDesign: template.survey_count_design,
             surveyCountCredible: template.survey_count_credible,
             surveyCountUseful: template.survey_count_useful,
+            totalLikes: template.total_like_count
         }
     });
 }
@@ -191,6 +192,7 @@ export const responseFromAllTemplatesLoggedIn = (templates) => {
             surveyCountDesign: template.survey_count_design,
             surveyCountCredible: template.survey_count_credible,
             surveyCountUseful: template.survey_count_useful,
+            totalLikes: template.total_like_count
         }
     });
 }


### PR DESCRIPTION
게시물, 템플릿 별 총 좋아요 개수 집계 (메인페이지)
- 해당되는 api:  템플릿 목록 조회 api (로그인 전/후), 게시물 전체 조회 api (로그인 전/후)
- 스웨거 수정도 했습니다.